### PR TITLE
Reimplemented SetTimeout/SetInterval through CreateTimerQueue [Issue #3]

### DIFF
--- a/src/host.cpp
+++ b/src/host.cpp
@@ -85,17 +85,17 @@ t_script_info& HostComm::ScriptInfo()
 
 unsigned HostComm::SetInterval(IDispatch* func, INT delay)
 {
-	return m_host_timer_dispatcher.setInterval(delay, func);
+	return HostTimerDispatcher::Get().setInterval(m_hwnd, delay, func);
 }
 
 unsigned HostComm::SetTimeout(IDispatch* func, INT delay)
 {
-	return m_host_timer_dispatcher.setTimeout(delay, func);
+	return HostTimerDispatcher::Get().setTimeout(m_hwnd, delay, func);
 }
 
 void HostComm::ClearIntervalOrTimeout(UINT timerId)
 {
-	m_host_timer_dispatcher.kill(timerId);
+	HostTimerDispatcher::Get().killTimer(timerId);
 }
 
 void HostComm::PreserveSelection()

--- a/src/host.h
+++ b/src/host.h
@@ -24,7 +24,6 @@ protected:
 	HBITMAP m_gr_bmp_bk;
 	HDC m_hdc;
 	HWND m_hwnd;
-	HostTimerDispatcher m_host_timer_dispatcher;
 	INT m_height;
 	INT m_width;
 	POINT m_max_size;

--- a/src/host_timer_dispatcher.cpp
+++ b/src/host_timer_dispatcher.cpp
@@ -2,90 +2,336 @@
 #include "host_timer_dispatcher.h"
 #include "user_message.h"
 
-HostTimerDispatcher::HostTimerDispatcher() : m_hWnd(NULL)
-{
-	TIMECAPS tc;
-	if (timeGetDevCaps(&tc, sizeof(TIMECAPS)) == TIMERR_NOERROR)
-	{
-		m_accuracy = min(max(tc.wPeriodMin, 5), tc.wPeriodMax);
-	}
 
-	timeBeginPeriod(m_accuracy);
+
+HostTimerDispatcher::HostTimerDispatcher() 
+{
+	m_curTimerId = 1;
+	m_hTimerQueue = CreateTimerQueue();
 }
 
 HostTimerDispatcher::~HostTimerDispatcher()
 {
-	reset();
-	timeEndPeriod(m_accuracy);
+	stopThread();
+	// Clear all references
+	m_taskMap.clear();
 }
 
-unsigned HostTimerDispatcher::setInterval(unsigned delay, IDispatch* pDisp)
+HostTimerDispatcher& HostTimerDispatcher::Get()
 {
-	if (!pDisp) return 0;
-	unsigned timerID = timeSetEvent(delay, m_accuracy, g_timer_proc, reinterpret_cast<DWORD_PTR>(m_hWnd), TIME_PERIODIC);
-	addTimerMap(timerID, pDisp);
-	return timerID;
+	static HostTimerDispatcher timerDispatcher;
+	return timerDispatcher;
 }
 
-unsigned HostTimerDispatcher::setTimeout(unsigned delay, IDispatch* pDisp)
+unsigned HostTimerDispatcher::setInterval(HWND hWnd, unsigned delay, IDispatch* pDisp)
 {
-	if (!pDisp) return 0;
-	unsigned timerID = timeSetEvent(delay, m_accuracy, g_timer_proc, reinterpret_cast<DWORD_PTR>(m_hWnd), TIME_ONESHOT);
-	addTimerMap(timerID, pDisp);
-	return timerID;
+	return createTimer(hWnd, delay, true, pDisp);
 }
 
-void HostTimerDispatcher::invoke(UINT timerId)
+unsigned HostTimerDispatcher::setTimeout(HWND hWnd, unsigned delay, IDispatch* pDisp)
 {
-	IDispatch* pDisp = NULL;
-	if (!m_timerDispatchMap.query(timerId, pDisp) || !pDisp)
+	return createTimer(hWnd, delay, false, pDisp);
+}
+
+void HostTimerDispatcher::killTimer(unsigned timerId)
+{
+	{
+		std::lock_guard<std::mutex> lock(m_timerMutex);
+
+		auto timerIter = m_timerMap.find(timerId);
+		if (m_timerMap.end() != timerIter)
+		{
+			timerIter->second->stop();
+		}		
+	}
+
+	auto taskIter = m_taskMap.find(timerId);
+	if (m_taskMap.end() != taskIter)
+	{
+		taskIter->second->release();
+	}
+}
+
+void HostTimerDispatcher::onPanelUnload(HWND hWnd)
+{
+	std::list<unsigned> timersToDelete;
+
+	{
+		std::lock_guard<std::mutex> lock(m_timerMutex);
+		for each (const auto& elem in m_timerMap)
+		{
+			if (elem.second->GetHwnd() == hWnd) {
+				timersToDelete.push_back(elem.first);
+			}
+		}
+	}
+
+	for each (auto timerId in timersToDelete)
+	{
+		killTimer(timerId);
+	}
+}
+
+void HostTimerDispatcher::onInvokeMessage(unsigned timerId)
+{
+	if (m_taskMap.end() != m_taskMap.find(timerId))
+	{
+		m_taskMap[timerId]->invoke();
+	}
+}
+
+void HostTimerDispatcher::onTimerExpire(unsigned timerId)
+{
+	std::unique_lock<std::mutex> lock(m_timerMutex);
+
+	m_timerMap.erase(timerId);
+}
+
+void HostTimerDispatcher::onTimerStopRequest(HWND hWnd, HANDLE hTimer, unsigned timerId)
+{
+	std::unique_lock<std::mutex> lock(m_threadTaskMutex);
+
+	ThreadTask threadTask = {};
+	threadTask.taskId = killTimerTask;
+	threadTask.hWnd = hWnd;
+	threadTask.hTimer = hTimer;
+	threadTask.timerId = timerId;
+
+	m_threadTaskList.push_front(threadTask);
+	m_cv.notify_one();
+}
+
+void HostTimerDispatcher::onTaskComplete(unsigned timerId)
+{
+	if (m_taskMap.end() != m_taskMap.find(timerId))
+	{
+		m_taskMap.erase(timerId);
+	}
+}
+
+unsigned HostTimerDispatcher::createTimer(HWND hWnd, unsigned delay, bool isRepeated, IDispatch* pDisp)
+{
+	if (!pDisp)
+	{
+		return 0;
+	}
+
+	std::lock_guard<std::mutex> lock(m_timerMutex);
+
+	unsigned id = m_curTimerId++;
+	while (m_taskMap.end() != m_taskMap.find(id) && m_timerMap.end() != m_timerMap.find(id))
+	{
+		id = m_curTimerId++;
+	}
+
+	m_timerMap.emplace(id, new HostTimer(hWnd, id, delay, isRepeated));
+
+	auto & curTask = m_taskMap.emplace(id, new HostTimerTask(pDisp, id));
+	curTask.first->second->acquire();
+
+	if (!m_timerMap[id]->start(m_hTimerQueue))
+	{
+		m_timerMap.erase(id);
+		m_taskMap.erase(id);
+		return 0;
+	}
+
+	return id;
+}
+
+void HostTimerDispatcher::createThread()
+{
+	m_thread = new std::thread(&HostTimerDispatcher::threadMain, this);
+}
+
+void HostTimerDispatcher::stopThread()
+{
+	if (!m_thread)
+	{
 		return;
+	}
+
+	{
+		std::lock_guard<std::mutex> lock(m_threadTaskMutex);
+		ThreadTask threadTask = {};
+		threadTask.taskId = shutdownTask;
+
+		m_threadTaskList.push_front(threadTask);
+		m_cv.notify_one();
+	}
+
+	if (m_thread->joinable())
+	{
+		m_thread->join();
+	}
+
+	delete m_thread;
+	m_thread = NULL;
+}
+
+void HostTimerDispatcher::threadMain()
+{
+	while (true)
+	{
+		ThreadTask threadTask;
+		{
+			std::unique_lock<std::mutex> lock(m_threadTaskMutex);
+
+			while (m_threadTaskList.empty())
+			{
+				m_cv.wait(lock);
+			}
+
+			if (m_threadTaskList.empty())
+			{
+				continue;
+			}
+
+			threadTask = m_threadTaskList.front();
+			m_threadTaskList.pop_front();
+		}
+
+		switch (threadTask.taskId)
+		{
+		case killTimerTask:
+		{
+			DeleteTimerQueueTimer(m_hTimerQueue, threadTask.hTimer, INVALID_HANDLE_VALUE);
+			onTimerExpire(threadTask.timerId);
+			
+			break;
+		}
+		case shutdownTask:
+		{
+			DeleteTimerQueueEx(m_hTimerQueue, INVALID_HANDLE_VALUE);
+			m_hTimerQueue = NULL;
+
+			return;
+		}
+		default:
+		{
+			assert(0);
+			break;
+		}
+		}
+	}
+}
+
+HostTimerTask::HostTimerTask(IDispatch * pDisp, unsigned timerId)
+{
+	m_pDisp = pDisp;
+	m_timerId = timerId;
+
+	m_refCount = 0;
+	m_pDisp->AddRef();
+}
+
+HostTimerTask::~HostTimerTask()
+{
+	m_pDisp->Release();
+}
+
+void HostTimerTask::acquire()
+{
+	++m_refCount;
+}
+
+void HostTimerTask::release()
+{
+	if (!m_refCount)
+	{
+		return;
+	}
+
+	--m_refCount;
+	if (!m_refCount)
+	{
+		HostTimerDispatcher::Get().onTaskComplete(m_timerId);
+	}
+}
+
+void HostTimerTask::invoke()
+{
+	acquire();
 
 	VARIANTARG args[1];
 	args[0].vt = VT_I4;
-	args[0].lVal = timerId;
+	args[0].lVal = m_timerId;
 	DISPPARAMS dispParams = { args, NULL, _countof(args), 0 };
-	pDisp->Invoke(DISPID_VALUE, IID_NULL, LOCALE_USER_DEFAULT, DISPATCH_METHOD, &dispParams, NULL, NULL, NULL);
+	m_pDisp->Invoke(DISPID_VALUE, IID_NULL, LOCALE_USER_DEFAULT, DISPATCH_METHOD, &dispParams, NULL, NULL, NULL);
+
+	release();
 }
 
-void HostTimerDispatcher::kill(unsigned timerID)
+HostTimer::HostTimer(HWND hWnd, unsigned id, unsigned delay, bool isRepeated)
 {
-	timeKillEvent(timerID);
+	m_hTimer = 0;
 
-	if (m_timerDispatchMap.exists(timerID))
-	{
-		IDispatch* pDisp = m_timerDispatchMap[timerID];
-		if (pDisp) pDisp->Release();
-		m_timerDispatchMap.remove(timerID);
-	}
-}
-
-void HostTimerDispatcher::reset()
-{
-	for (auto iter = m_timerDispatchMap.first(); iter.is_valid(); iter++)
-	{
-		timeKillEvent(iter->m_key);
-		IDispatch* pDisp = iter->m_value;
-		if (pDisp) pDisp->Release();
-	}
-
-	m_timerDispatchMap.remove_all();
-}
-
-void HostTimerDispatcher::setWindow(HWND hWnd)
-{
 	m_hWnd = hWnd;
+	m_delay = delay;
+	m_isRepeated = isRepeated;
+	m_id = id;
+
+	m_isStopRequested = false;
+	m_isStopped = false;
 }
 
-void HostTimerDispatcher::addTimerMap(unsigned timerID, IDispatch* pDisp)
+HostTimer::~HostTimer()
 {
-	PFC_ASSERT(pDisp != NULL);
-	pDisp->AddRef();
-	m_timerDispatchMap[timerID] = pDisp;
+
 }
 
-void CALLBACK HostTimerDispatcher::g_timer_proc(UINT uTimerID, UINT uMsg, DWORD_PTR dwUser, DWORD_PTR dw1, DWORD_PTR dw2)
+bool HostTimer::start(HANDLE hTimerQueue)
 {
-	HWND hWnd = reinterpret_cast<HWND>(dwUser);
-	SendMessage(hWnd, UWM_TIMER, uTimerID, 0);
+	return !!CreateTimerQueueTimer(
+		&m_hTimer,
+		hTimerQueue,
+		HostTimer::timerProc,
+		this,
+		m_delay,
+		m_isRepeated ? m_delay : 0,
+		WT_EXECUTEINTIMERTHREAD | (m_isRepeated ? 0 : WT_EXECUTEONLYONCE));
+}
+
+void HostTimer::stop()
+{
+	m_isStopRequested = true;
+}
+
+VOID CALLBACK HostTimer::timerProc(PVOID lpParameter, BOOLEAN TimerOrWaitFired)
+{
+	HostTimer* timer = (HostTimer*)lpParameter;
+
+	if (timer->m_isStopped)
+	{
+		return;
+	}
+
+	if (timer->m_isStopRequested)
+	{
+		timer->m_isStopped = true;
+		HostTimerDispatcher::Get().onTimerStopRequest(timer->m_hWnd, timer->m_hTimer, timer->m_id);
+
+		return;
+	}
+
+	if (!timer->m_isRepeated)
+	{
+		timer->m_isStopped = true;
+		SendMessage(timer->m_hWnd, UWM_TIMER, timer->m_id, 0);
+		HostTimerDispatcher::Get().onTimerStopRequest(timer->m_hWnd, timer->m_hTimer, timer->m_id);
+
+		return;
+	}
+
+	SendMessage(timer->m_hWnd, UWM_TIMER, timer->m_id, 0);
+}
+
+HWND HostTimer::GetHwnd() const
+{
+	return m_hWnd;
+}
+
+HANDLE HostTimer::GetHandle() const
+{
+	return m_hTimer;
 }

--- a/src/host_timer_dispatcher.h
+++ b/src/host_timer_dispatcher.h
@@ -1,26 +1,162 @@
 #pragma once
 
+#include <mutex>
+#include <map>
+#include <atomic>
+#include <list>
+
+
+class HostTimer;
+class HostTimerTask;
+
+
+/// @brief Handles JS requests for setInterval, setTimeout, clearInterval, clearTimeout.
+/// @details
+/// Everything happens inside of the main thread except for:
+/// - Timer procs: timer proc is called from a worker thread, but JS callback 
+///                handling is given back to main thread through window messaging.
+/// - Timer destruction: a separate 'killer' thread handles this.
+///
+/// Usual workflow is like this (MainThread == MT, WorkerThread == WT, KillerThread == KT):
+/// MT:createTimer -> MT:timer.start -> WT:proc(timer) >> window_msg >> MT:task.invoke
+///                                          \-> WT:timer.remove -> KT:waitForTimer -> KT:killTimer
 class HostTimerDispatcher
 {
 public:
-	HostTimerDispatcher();
 	~HostTimerDispatcher();
 
-	unsigned setInterval(unsigned delay, IDispatch* pDisp);
-	unsigned setTimeout(unsigned delay, IDispatch* pDisp);
-	void invoke(UINT timerId);
-	void kill(unsigned timerID);
-	void reset();
-	void setWindow(HWND hWnd);
+	static HostTimerDispatcher& Get();
+
+	unsigned setInterval(HWND hWnd, unsigned delay, IDispatch* pDisp);
+	unsigned setTimeout(HWND hWnd, unsigned delay, IDispatch* pDisp);
+
+	void killTimer(unsigned timerId);
+
+public: // callbacks
+	void onPanelUnload(HWND hWnd);
+
+	/// @brief Callback from timer via window message
+	/// @details WT:timerProc >> window_msg >> MT:invoke
+	void onInvokeMessage(unsigned timerId);
+
+	/// @brief Callback from Killer Thread when timer is expired
+	void onTimerExpire(unsigned timerId);
+
+	/// @brief Callback from HostTimer when timer proc finished execution
+	void onTimerStopRequest(HWND hWnd, HANDLE hTimer, unsigned timerId);
+
+	/// @brief Callback from HostTimerTask when task has been completed
+	void onTaskComplete(unsigned timerId);
 
 private:
-	void addTimerMap(unsigned timerID, IDispatch* pDisp);
+	HostTimerDispatcher();
 
-	static void CALLBACK g_timer_proc(UINT uTimerID, UINT uMsg, DWORD_PTR dwUser, DWORD_PTR dw1, DWORD_PTR dw2);
+	unsigned createTimer(HWND hWnd, unsigned delay, bool isRepeated, IDispatch* pDisp);
 
-	unsigned m_accuracy;
+private: //thread
+	enum ThreadTaskId
+	{
+		killTimerTask,
+		shutdownTask
+	};
+
+	void createThread();
+	void stopThread();
+
+	void threadMain();
+
+private:
+	typedef std::map<unsigned, std::unique_ptr<HostTimer>> TimerMap;
+	typedef std::map<unsigned, std::unique_ptr<HostTimerTask>> TaskMap;	
+
+	std::mutex m_timerMutex;
+
+	HANDLE m_hTimerQueue;
+	
+	TimerMap m_timerMap;
+	TaskMap m_taskMap;
+
+	unsigned m_curTimerId;
+
+private: // thread
+	typedef struct
+	{
+		ThreadTaskId taskId;
+
+		HWND hWnd;
+		unsigned timerId;
+		HANDLE hTimer;
+	} ThreadTask;
+
+	std::thread* m_thread;
+
+	std::mutex m_threadTaskMutex;
+	std::list<ThreadTask> m_threadTaskList;
+
+	std::condition_variable m_cv;
+};
+
+/// @brief Task that should be executed on timer proc
+/// @details Also handles IDispatch references
+class HostTimerTask
+{
+public:
+	/// @brief ctor
+	/// @details Adds reference to pDisp
+	HostTimerTask(IDispatch * pDisp, unsigned timerId);
+
+	/// @brief dtor
+	/// @details Removes reference from pDisp
+	~HostTimerTask();
+
+	/// @brief Adds reference to task
+	void acquire();
+
+	/// @brief Removes reference from task
+	/// @details Self-destruct when task reference is zero
+	void release();
+
+	/// @brief Invokes JS callback
+	/// @details Adds task reference on enter and removes on exit,
+	///          so if the corresponding timer is dead, it will self-destruct.
+	void invoke();
+
+private:
+	IDispatch * m_pDisp;
+
+	unsigned m_timerId;
+	unsigned m_refCount;
+};
+
+class HostTimer
+{
+public:
+	HostTimer(HWND hWnd, unsigned id, unsigned delay, bool isRepeated);
+	~HostTimer();
+
+	bool start(HANDLE hTimerQueue);
+	void stop();
+
+	/// @brief Timer proc.
+	/// @details Short execution, since it only sends window message to MT:invoke.
+	///          If it's a timeout timer, requests self-removal from killer thread.
+	///
+	/// @param[in] lpParameter Pointer to HostTimer object
+	static VOID CALLBACK timerProc(PVOID lpParameter, BOOLEAN TimerOrWaitFired);
+
+	HWND GetHwnd() const;
+	HANDLE GetHandle() const;
+
+private:
 	HWND m_hWnd;
 
-	typedef pfc::map_t<UINT, IDispatch *> TimerDispatchMap;
-	TimerDispatchMap m_timerDispatchMap;
+	IDispatch * m_pDisp;
+	HANDLE m_hTimer;
+
+	unsigned m_id;
+	unsigned m_delay;
+	bool m_isRepeated;
+
+	std::atomic<bool> m_isStopRequested;
+	bool m_isStopped;
 };

--- a/src/js_panel_window.cpp
+++ b/src/js_panel_window.cpp
@@ -412,7 +412,7 @@ LRESULT js_panel_window::on_message(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp)
 		return 0;
 
 	case UWM_TIMER:
-		m_host_timer_dispatcher.invoke(wp);
+		HostTimerDispatcher::Get().onInvokeMessage(wp);
 		return 0;
 	}
 
@@ -473,8 +473,6 @@ void js_panel_window::execute_context_menu_command(int id, int id_base)
 
 bool js_panel_window::script_load()
 {
-	m_host_timer_dispatcher.setWindow(m_hwnd);
-
 	pfc::hires_timer timer;
 	bool result = true;
 	timer.start();
@@ -1204,6 +1202,6 @@ void js_panel_window::script_unload()
 		m_is_droptarget_registered = false;
 	}
 
-	m_host_timer_dispatcher.reset();
+	HostTimerDispatcher::Get().onPanelUnload(m_hwnd);
 	m_selection_holder.release();
 }


### PR DESCRIPTION
Replaced timeSetEvent() with CreateTimerQueue() and CreateTimerQueueTimer()

Fixes #3.

Basic control flow description (MainThread == MT, WorkerThread == WT, KillerThread == KT):
1. MT: 
    timer = createTimer()       
    task = createTask(jsProc)
1. MT: timer.start()
1. WR: timer_proc(timer)
   1. WR: send(window_msg)
      1. MT: task.jsProc()
   1. WR: request_timer_kill
      1. KR: waitForFinish(timer)
      2. KR: delete((timer))
 
Notes:
Previous implementation had another bug - pDisp was never released after createTimeout unless the timer was killed, thus it's references would never be equal to zero, which in turn would create a memory leak.