### PR TITLE
Fixing color component overflow in GetColourSchemeJSON

### DIFF
--- a/src/script_interface/script_interface.cpp
+++ b/src/script_interface/script_interface.cpp
@@ -393,13 +393,11 @@ STDMETHODIMP GdiBitmap::GetColourSchemeJSON(UINT count, BSTR* p)
 		BYTE g = (colours[i] >> 8) & 0xff;
 		BYTE b = (colours[i] & 0xff);
 
-		r = (r + 4) & 0xfffffff8;
-		g = (g + 4) & 0xfffffff8;
-		b = (b + 4) & 0xfffffff8;
-
-		if (r > 255) r = 0xff;
-		if (g > 255) g = 0xff;
-		if (b > 255) b = 0xff;
+		// We're reducing total colors from 2^24 to 2^15 by rounding each color component value to multiples of 8.
+		// First we need to check if the byte will overflow, and if so pin to 0xff, otherwise add 4 and round down.
+		r = (r > 251) ? 0xff : (r + 4) & 0xf8;
+		g = (g > 251) ? 0xff : (g + 4) & 0xf8;
+		b = (b > 251) ? 0xff : (b + 4) & 0xf8;
 
 		++colour_counters[r << 16 | g << 8 | b];
 	}


### PR DESCRIPTION
Discovered today that a regression got introduced to the GetColourSchemeJSON method several months ago when the RGB color components types were changed from `unsigned` to `BYTE`. Reworked the code better to keep everything as BYTEs while preventing overflow.

You can see the current broken behavior by running the method on the folder.jpg attached. The first color value returned in the array should be rgb(255,0,0) but instead is rgb(0,0,0) because the red value is OR'd as an `unsigned` and then coerced to a `BYTE` which truncates it.

![folder](https://user-images.githubusercontent.com/2282004/56086353-d22f8100-5e1a-11e9-9464-693051363844.jpg)
